### PR TITLE
feat: Phase 4 - GitHub連携・Google Calendar連携・PWA対応・PDFエクスポート

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -45,7 +45,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
-    "lib": ["dom", "dom.iterable", "dom.asynciterable", "deno.ns"]
+    "lib": ["dom", "dom.iterable", "dom.asynciterable", "deno.ns", "deno.unstable"]
   },
   "exclude": [
     "**/_fresh/*"

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -3,11 +3,20 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $_app from "./routes/_app.tsx";
+import * as $api_calendar_auth from "./routes/api/calendar/auth.ts";
+import * as $api_calendar_callback from "./routes/api/calendar/callback.ts";
+import * as $api_calendar_disconnect from "./routes/api/calendar/disconnect.ts";
+import * as $api_calendar_events from "./routes/api/calendar/events.ts";
 import * as $api_comments_id_ from "./routes/api/comments/[id].ts";
 import * as $api_entries_id_ from "./routes/api/entries/[id].ts";
 import * as $api_entries_id_comments from "./routes/api/entries/[id]/comments.ts";
 import * as $api_entries_id_reactions from "./routes/api/entries/[id]/reactions.ts";
 import * as $api_entries_index from "./routes/api/entries/index.ts";
+import * as $api_github_auth from "./routes/api/github/auth.ts";
+import * as $api_github_callback from "./routes/api/github/callback.ts";
+import * as $api_github_disconnect from "./routes/api/github/disconnect.ts";
+import * as $api_github_import from "./routes/api/github/import.ts";
+import * as $api_github_repos from "./routes/api/github/repos.ts";
 import * as $api_insights_index from "./routes/api/insights/index.ts";
 import * as $api_integrations_id_ from "./routes/api/integrations/[id].ts";
 import * as $api_integrations_index from "./routes/api/integrations/index.ts";
@@ -39,21 +48,28 @@ import * as $projects_new from "./routes/projects/new.tsx";
 import * as $reports_daily from "./routes/reports/daily.tsx";
 import * as $reports_monthly from "./routes/reports/monthly.tsx";
 import * as $reports_weekly from "./routes/reports/weekly.tsx";
+import * as $settings_github from "./routes/settings/github.tsx";
+import * as $settings_google_calendar from "./routes/settings/google-calendar.tsx";
 import * as $settings_index from "./routes/settings/index.tsx";
 import * as $settings_integrations from "./routes/settings/integrations.tsx";
 import * as $settings_templates from "./routes/settings/templates.tsx";
 import * as $standup_index from "./routes/standup/index.tsx";
+import * as $CalendarEvents from "./islands/CalendarEvents.tsx";
 import * as $DashboardIsland from "./islands/DashboardIsland.tsx";
 import * as $EntryForm from "./islands/EntryForm.tsx";
 import * as $EntryList from "./islands/EntryList.tsx";
 import * as $EntryReactions from "./islands/EntryReactions.tsx";
+import * as $GitHubSettingsIsland from "./islands/GitHubSettingsIsland.tsx";
+import * as $GoogleCalendarDisconnect from "./islands/GoogleCalendarDisconnect.tsx";
 import * as $InsightsIsland from "./islands/InsightsIsland.tsx";
 import * as $IntegrationSettingsIsland from "./islands/IntegrationSettingsIsland.tsx";
 import * as $KanbanBoard from "./islands/KanbanBoard.tsx";
 import * as $MemberManager from "./islands/MemberManager.tsx";
+import * as $PdfExportButton from "./islands/PdfExportButton.tsx";
 import * as $ProjectDeleteButton from "./islands/ProjectDeleteButton.tsx";
 import * as $ProjectForm from "./islands/ProjectForm.tsx";
 import * as $ProjectList from "./islands/ProjectList.tsx";
+import * as $PwaInstallPrompt from "./islands/PwaInstallPrompt.tsx";
 import * as $ReportView from "./islands/ReportView.tsx";
 import * as $StandupIsland from "./islands/StandupIsland.tsx";
 import * as $TemplateManager from "./islands/TemplateManager.tsx";
@@ -62,11 +78,20 @@ import type { Manifest } from "$fresh/server.ts";
 const manifest = {
   routes: {
     "./routes/_app.tsx": $_app,
+    "./routes/api/calendar/auth.ts": $api_calendar_auth,
+    "./routes/api/calendar/callback.ts": $api_calendar_callback,
+    "./routes/api/calendar/disconnect.ts": $api_calendar_disconnect,
+    "./routes/api/calendar/events.ts": $api_calendar_events,
     "./routes/api/comments/[id].ts": $api_comments_id_,
     "./routes/api/entries/[id].ts": $api_entries_id_,
     "./routes/api/entries/[id]/comments.ts": $api_entries_id_comments,
     "./routes/api/entries/[id]/reactions.ts": $api_entries_id_reactions,
     "./routes/api/entries/index.ts": $api_entries_index,
+    "./routes/api/github/auth.ts": $api_github_auth,
+    "./routes/api/github/callback.ts": $api_github_callback,
+    "./routes/api/github/disconnect.ts": $api_github_disconnect,
+    "./routes/api/github/import.ts": $api_github_import,
+    "./routes/api/github/repos.ts": $api_github_repos,
     "./routes/api/insights/index.ts": $api_insights_index,
     "./routes/api/integrations/[id].ts": $api_integrations_id_,
     "./routes/api/integrations/index.ts": $api_integrations_index,
@@ -98,23 +123,30 @@ const manifest = {
     "./routes/reports/daily.tsx": $reports_daily,
     "./routes/reports/monthly.tsx": $reports_monthly,
     "./routes/reports/weekly.tsx": $reports_weekly,
+    "./routes/settings/github.tsx": $settings_github,
+    "./routes/settings/google-calendar.tsx": $settings_google_calendar,
     "./routes/settings/index.tsx": $settings_index,
     "./routes/settings/integrations.tsx": $settings_integrations,
     "./routes/settings/templates.tsx": $settings_templates,
     "./routes/standup/index.tsx": $standup_index,
   },
   islands: {
+    "./islands/CalendarEvents.tsx": $CalendarEvents,
     "./islands/DashboardIsland.tsx": $DashboardIsland,
     "./islands/EntryForm.tsx": $EntryForm,
     "./islands/EntryList.tsx": $EntryList,
     "./islands/EntryReactions.tsx": $EntryReactions,
+    "./islands/GitHubSettingsIsland.tsx": $GitHubSettingsIsland,
+    "./islands/GoogleCalendarDisconnect.tsx": $GoogleCalendarDisconnect,
     "./islands/InsightsIsland.tsx": $InsightsIsland,
     "./islands/IntegrationSettingsIsland.tsx": $IntegrationSettingsIsland,
     "./islands/KanbanBoard.tsx": $KanbanBoard,
     "./islands/MemberManager.tsx": $MemberManager,
+    "./islands/PdfExportButton.tsx": $PdfExportButton,
     "./islands/ProjectDeleteButton.tsx": $ProjectDeleteButton,
     "./islands/ProjectForm.tsx": $ProjectForm,
     "./islands/ProjectList.tsx": $ProjectList,
+    "./islands/PwaInstallPrompt.tsx": $PwaInstallPrompt,
     "./islands/ReportView.tsx": $ReportView,
     "./islands/StandupIsland.tsx": $StandupIsland,
     "./islands/TemplateManager.tsx": $TemplateManager,

--- a/islands/CalendarEvents.tsx
+++ b/islands/CalendarEvents.tsx
@@ -1,0 +1,106 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+
+interface CalendarEventItem {
+  id: string;
+  summary: string;
+  startTime: string | null;
+  isAllDay: boolean;
+  displayText: string;
+}
+
+export default function CalendarEvents() {
+  const events = useSignal<CalendarEventItem[]>([]);
+  const loading = useSignal(true);
+  const connected = useSignal(true);
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+
+    fetch(`/api/calendar/events?date=${today}`)
+      .then((res) => res.json())
+      .then((json) => {
+        if (json.success) {
+          events.value = json.data;
+        } else {
+          // 未連携や認証エラーの場合はサイレントに非表示
+          connected.value = false;
+        }
+      })
+      .catch(() => {
+        connected.value = false;
+      })
+      .finally(() => {
+        loading.value = false;
+      });
+  }, []);
+
+  // 未連携・エラー時は何も表示しない
+  if (!connected.value) return null;
+
+  // ローディング中
+  if (loading.value) {
+    return (
+      <div class="bg-blue-50 border border-blue-100 rounded-lg px-4 py-3 mb-4">
+        <div class="flex items-center gap-2 text-blue-600 text-sm">
+          <svg
+            class="animate-spin h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path
+              class="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+          <span>カレンダーを読み込み中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  // イベントがない場合
+  if (events.value.length === 0) {
+    return (
+      <div class="bg-blue-50 border border-blue-100 rounded-lg px-4 py-3 mb-4">
+        <p class="text-blue-600 text-sm">今日の予定はありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div class="bg-blue-50 border border-blue-100 rounded-lg px-4 py-3 mb-4">
+      <div class="flex items-center gap-2 mb-2">
+        <svg
+          class="h-4 w-4 text-blue-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+        <span class="text-blue-700 text-sm font-medium">今日の予定</span>
+      </div>
+      <ul class="space-y-1">
+        {events.value.map((event) => (
+          <li key={event.id} class="text-sm text-blue-800">
+            {event.displayText}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/islands/GitHubSettingsIsland.tsx
+++ b/islands/GitHubSettingsIsland.tsx
@@ -1,0 +1,274 @@
+import { useSignal } from "@preact/signals";
+
+interface GitHubConnectionData {
+  githubLogin: string;
+  lastImportedAt: string | null;
+}
+
+interface RepoData {
+  name: string;
+  fullName: string;
+  owner: string;
+  description: string | null;
+  private: boolean;
+  updatedAt: string;
+}
+
+interface GitHubSettingsProps {
+  connection: GitHubConnectionData | null;
+}
+
+export default function GitHubSettingsIsland(
+  { connection: initialConnection }: GitHubSettingsProps,
+) {
+  const connection = useSignal<GitHubConnectionData | null>(initialConnection);
+  const repos = useSignal<RepoData[]>([]);
+  const reposLoaded = useSignal(false);
+  const reposLoading = useSignal(false);
+  const selectedRepo = useSignal<RepoData | null>(null);
+  const importing = useSignal(false);
+  const disconnecting = useSignal(false);
+  const error = useSignal<string | null>(null);
+  const success = useSignal<string | null>(null);
+  const sinceDays = useSignal("7");
+
+  async function handleDisconnect() {
+    if (!confirm("GitHub連携を解除しますか？")) return;
+
+    disconnecting.value = true;
+    error.value = null;
+
+    try {
+      const res = await fetch("/api/github/disconnect", { method: "DELETE" });
+      const json = await res.json();
+      if (!json.success) {
+        error.value = json.error || "解除に失敗しました";
+        return;
+      }
+      connection.value = null;
+      repos.value = [];
+      reposLoaded.value = false;
+      selectedRepo.value = null;
+      success.value = "GitHub連携を解除しました";
+      setTimeout(() => (success.value = null), 3000);
+    } catch {
+      error.value = "ネットワークエラーが発生しました";
+    } finally {
+      disconnecting.value = false;
+    }
+  }
+
+  async function handleLoadRepos() {
+    reposLoading.value = true;
+    error.value = null;
+
+    try {
+      const res = await fetch("/api/github/repos");
+      const json = await res.json();
+      if (!json.success) {
+        error.value = json.error || "リポジトリの取得に失敗しました";
+        return;
+      }
+      repos.value = json.data;
+      reposLoaded.value = true;
+    } catch {
+      error.value = "ネットワークエラーが発生しました";
+    } finally {
+      reposLoading.value = false;
+    }
+  }
+
+  async function handleImport() {
+    if (!selectedRepo.value) {
+      error.value = "リポジトリを選択してください";
+      return;
+    }
+
+    importing.value = true;
+    error.value = null;
+    success.value = null;
+
+    const days = parseInt(sinceDays.value, 10) || 7;
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    try {
+      const res = await fetch("/api/github/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          owner: selectedRepo.value.owner,
+          repo: selectedRepo.value.name,
+          since: since.toISOString(),
+        }),
+      });
+
+      const json = await res.json();
+      if (!json.success) {
+        error.value = json.error || "インポートに失敗しました";
+        return;
+      }
+
+      success.value = `${json.data.importedCount}件のコミットをインポートしました`;
+      if (connection.value) {
+        connection.value = {
+          ...connection.value,
+          lastImportedAt: new Date().toISOString(),
+        };
+      }
+      setTimeout(() => (success.value = null), 5000);
+    } catch {
+      error.value = "ネットワークエラーが発生しました";
+    } finally {
+      importing.value = false;
+    }
+  }
+
+  // 未連携
+  if (!connection.value) {
+    return (
+      <div class="space-y-4">
+        {error.value && (
+          <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            {error.value}
+          </div>
+        )}
+        {success.value && (
+          <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+            {success.value}
+          </div>
+        )}
+        <div class="text-center py-10 text-gray-400">
+          <p class="text-4xl mb-3">&#x1F4BB;</p>
+          <p class="text-sm mb-4">GitHubアカウントが連携されていません</p>
+          <a
+            href="/api/github/auth"
+            class="inline-block bg-gray-900 hover:bg-gray-800 text-white text-sm font-semibold px-6 py-2.5 rounded-lg transition-colors"
+          >
+            GitHubと連携する
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // 連携済み
+  return (
+    <div class="space-y-6">
+      {error.value && (
+        <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+          {error.value}
+        </div>
+      )}
+      {success.value && (
+        <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+          {success.value}
+        </div>
+      )}
+
+      {/* 連携情報 */}
+      <div class="bg-white border border-gray-200 rounded-lg p-4">
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-xs font-semibold px-2 py-0.5 rounded-full bg-green-100 text-green-700">
+                連携済み
+              </span>
+              <span class="text-sm font-medium text-gray-900">
+                @{connection.value.githubLogin}
+              </span>
+            </div>
+            {connection.value.lastImportedAt && (
+              <p class="text-xs text-gray-500">
+                最終インポート: {new Date(connection.value.lastImportedAt).toLocaleString("ja-JP")}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleDisconnect}
+            disabled={disconnecting.value}
+            class="text-xs text-red-500 hover:text-red-700 font-medium disabled:opacity-50"
+          >
+            {disconnecting.value ? "解除中..." : "連携解除"}
+          </button>
+        </div>
+      </div>
+
+      {/* コミットインポート */}
+      <div class="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+        <h3 class="text-sm font-semibold text-gray-900">
+          コミットをインポート
+        </h3>
+        <p class="text-xs text-gray-500">
+          GitHubリポジトリのコミットを分報として取り込みます
+        </p>
+
+        {!reposLoaded.value
+          ? (
+            <button
+              type="button"
+              onClick={handleLoadRepos}
+              disabled={reposLoading.value}
+              class="bg-brand-600 hover:bg-brand-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+            >
+              {reposLoading.value ? "読み込み中..." : "リポジトリを読み込む"}
+            </button>
+          )
+          : (
+            <div class="space-y-3">
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  リポジトリ
+                </label>
+                <select
+                  class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 text-sm"
+                  value={selectedRepo.value?.fullName || ""}
+                  onChange={(e) => {
+                    const val = (e.target as HTMLSelectElement).value;
+                    selectedRepo.value = repos.value.find((r) => r.fullName === val) || null;
+                  }}
+                  disabled={importing.value}
+                >
+                  <option value="">-- 選択してください --</option>
+                  {repos.value.map((r) => (
+                    <option key={r.fullName} value={r.fullName}>
+                      {r.fullName}
+                      {r.private ? " (private)" : ""}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label class="block text-sm font-medium text-gray-700 mb-1">
+                  取得期間（過去N日）
+                </label>
+                <select
+                  class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 text-sm"
+                  value={sinceDays.value}
+                  onChange={(e) => (sinceDays.value = (e.target as HTMLSelectElement).value)}
+                  disabled={importing.value}
+                >
+                  <option value="1">1日</option>
+                  <option value="3">3日</option>
+                  <option value="7">7日</option>
+                  <option value="14">14日</option>
+                  <option value="30">30日</option>
+                </select>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleImport}
+                disabled={importing.value || !selectedRepo.value}
+                class="bg-brand-600 hover:bg-brand-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
+              >
+                {importing.value ? "インポート中..." : "インポート実行"}
+              </button>
+            </div>
+          )}
+      </div>
+    </div>
+  );
+}

--- a/islands/GoogleCalendarDisconnect.tsx
+++ b/islands/GoogleCalendarDisconnect.tsx
@@ -1,0 +1,33 @@
+import { useSignal } from "@preact/signals";
+
+export default function GoogleCalendarDisconnect() {
+  const disconnecting = useSignal(false);
+
+  async function handleDisconnect() {
+    if (!confirm("Google Calendar連携を解除しますか？")) return;
+
+    disconnecting.value = true;
+    try {
+      const res = await fetch("/api/calendar/disconnect", { method: "DELETE" });
+      const data = await res.json();
+      if (data.success) {
+        location.reload();
+      }
+    } catch {
+      // サイレント
+    } finally {
+      disconnecting.value = false;
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      class="text-sm text-red-600 hover:text-red-700 font-medium border border-red-200 rounded-lg px-4 py-2 hover:bg-red-50 transition-colors disabled:opacity-50"
+      onClick={handleDisconnect}
+      disabled={disconnecting.value}
+    >
+      {disconnecting.value ? "解除中..." : "連携を解除する"}
+    </button>
+  );
+}

--- a/islands/PdfExportButton.tsx
+++ b/islands/PdfExportButton.tsx
@@ -1,0 +1,39 @@
+interface PdfExportButtonProps {
+  title?: string;
+}
+
+export default function PdfExportButton({ title }: PdfExportButtonProps) {
+  function handlePrint() {
+    const originalTitle = document.title;
+    if (title) {
+      document.title = title;
+    }
+    globalThis.print();
+    if (title) {
+      document.title = originalTitle;
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handlePrint}
+      class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-indigo-300 text-indigo-600 rounded-lg hover:bg-indigo-50 transition-colors print-hidden"
+    >
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+        />
+      </svg>
+      PDF出力
+    </button>
+  );
+}

--- a/islands/PwaInstallPrompt.tsx
+++ b/islands/PwaInstallPrompt.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "preact/hooks";
+
+const DISMISS_KEY = "murlon_pwa_dismissed";
+
+export default function PwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<Event | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem(DISMISS_KEY)) return;
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+      setVisible(true);
+    };
+
+    globalThis.addEventListener("beforeinstallprompt", handler);
+    return () => globalThis.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+    // deno-lint-ignore no-explicit-any
+    (deferredPrompt as any).prompt();
+    // deno-lint-ignore no-explicit-any
+    await (deferredPrompt as any).userChoice;
+    setDeferredPrompt(null);
+    setVisible(false);
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div class="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:w-96 bg-white border border-gray-200 rounded-xl shadow-lg p-4 flex items-center gap-3 z-50">
+      <div class="flex-shrink-0 w-10 h-10 bg-indigo-100 rounded-lg flex items-center justify-center">
+        <span class="text-indigo-600 font-bold text-lg">M</span>
+      </div>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm font-medium text-gray-900">ホーム画面に追加</p>
+        <p class="text-xs text-gray-500">murlonをアプリとして使えます</p>
+      </div>
+      <button
+        type="button"
+        onClick={handleInstall}
+        class="flex-shrink-0 bg-indigo-600 text-white text-sm font-medium px-3 py-1.5 rounded-lg hover:bg-indigo-700"
+      >
+        追加
+      </button>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        class="flex-shrink-0 text-gray-400 hover:text-gray-600"
+        aria-label="閉じる"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-5 w-5"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,147 @@
+const GITHUB_API_BASE = "https://api.github.com";
+
+export interface GitHubRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  owner: { login: string };
+  description: string | null;
+  private: boolean;
+  html_url: string;
+  updated_at: string;
+}
+
+export interface GitHubCommit {
+  sha: string;
+  commit: {
+    message: string;
+    author: {
+      name: string;
+      date: string;
+    };
+  };
+  html_url: string;
+}
+
+export interface GitHubUser {
+  id: number;
+  login: string;
+  name: string | null;
+  avatar_url: string;
+}
+
+/**
+ * リポジトリ一覧を取得
+ */
+export async function fetchRepos(accessToken: string): Promise<GitHubRepo[]> {
+  const res = await fetch(
+    `${GITHUB_API_BASE}/user/repos?sort=updated&per_page=100`,
+    {
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "Accept": "application/vnd.github+json",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error(`GitHub APIエラー: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * コミット一覧を取得
+ */
+export async function fetchCommits(
+  accessToken: string,
+  owner: string,
+  repo: string,
+  since?: string,
+  until?: string,
+): Promise<GitHubCommit[]> {
+  const params = new URLSearchParams({ per_page: "100" });
+  if (since) params.set("since", since);
+  if (until) params.set("until", until);
+
+  const res = await fetch(
+    `${GITHUB_API_BASE}/repos/${owner}/${repo}/commits?${params}`,
+    {
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "Accept": "application/vnd.github+json",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error(`GitHub APIエラー: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * GitHubユーザー情報を取得
+ */
+export async function fetchGitHubUser(
+  accessToken: string,
+): Promise<GitHubUser> {
+  const res = await fetch(`${GITHUB_API_BASE}/user`, {
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Accept": "application/vnd.github+json",
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub APIエラー: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * アクセストークンを取得（OAuth code交換）
+ */
+export async function exchangeCodeForToken(
+  code: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<string> {
+  const res = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub OAuth トークン交換に失敗しました: ${res.status}`);
+  }
+
+  const data = await res.json();
+  if (data.error) {
+    throw new Error(`GitHub OAuth エラー: ${data.error_description || data.error}`);
+  }
+
+  return data.access_token;
+}
+
+/**
+ * コミットをEntry形式のcontentに変換
+ */
+export function formatCommitAsEntry(
+  commit: GitHubCommit,
+  repoName: string,
+): string {
+  const message = commit.commit.message.split("\n")[0]; // 最初の行のみ
+  return `[GitHub] ${repoName}: ${message}`;
+}

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -1,0 +1,162 @@
+export interface CalendarEvent {
+  id: string;
+  summary: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  description?: string;
+  location?: string;
+}
+
+interface CalendarListResponse {
+  items?: CalendarEvent[];
+  error?: { message: string; code: number };
+}
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+  refresh_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * 指定日のカレンダーイベント一覧を取得
+ */
+export async function fetchEvents(
+  accessToken: string,
+  date: string,
+): Promise<CalendarEvent[]> {
+  const timeMin = new Date(`${date}T00:00:00`).toISOString();
+  const timeMax = new Date(`${date}T23:59:59`).toISOString();
+
+  const params = new URLSearchParams({
+    timeMin,
+    timeMax,
+    singleEvents: "true",
+    orderBy: "startTime",
+  });
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const errorBody = await res.text();
+    throw new Error(`Google Calendar APIエラー: ${res.status} ${errorBody}`);
+  }
+
+  const data: CalendarListResponse = await res.json();
+  return data.items ?? [];
+}
+
+/**
+ * リフレッシュトークンを使ってアクセストークンを更新
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+): Promise<{ accessToken: string; expiresAt: Date }> {
+  const clientId = Deno.env.get("GOOGLE_CLIENT_ID");
+  const clientSecret = Deno.env.get("GOOGLE_CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    throw new Error("GOOGLE_CLIENT_IDまたはGOOGLE_CLIENT_SECRETが設定されていません");
+  }
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+
+  const data: TokenResponse = await res.json();
+
+  if (data.error) {
+    throw new Error(
+      `トークン更新エラー: ${data.error} - ${data.error_description}`,
+    );
+  }
+
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000);
+
+  return {
+    accessToken: data.access_token,
+    expiresAt,
+  };
+}
+
+/**
+ * カレンダーイベントを "HH:mm タイトル" 形式の文字列に変換
+ */
+export function formatEventForDisplay(event: CalendarEvent): string {
+  const startStr = event.start.dateTime ?? event.start.date;
+  if (!startStr) return event.summary || "(無題)";
+
+  if (event.start.dateTime) {
+    const date = new Date(event.start.dateTime);
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    return `${hours}:${minutes} ${event.summary || "(無題)"}`;
+  }
+
+  // 終日イベント
+  return `終日 ${event.summary || "(無題)"}`;
+}
+
+/**
+ * 認可コードをトークンに交換
+ */
+export async function exchangeCodeForTokens(
+  code: string,
+  redirectUri: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresAt: Date }> {
+  const clientId = Deno.env.get("GOOGLE_CLIENT_ID");
+  const clientSecret = Deno.env.get("GOOGLE_CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    throw new Error("GOOGLE_CLIENT_IDまたはGOOGLE_CLIENT_SECRETが設定されていません");
+  }
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  const data: TokenResponse = await res.json();
+
+  if (data.error) {
+    throw new Error(
+      `トークン交換エラー: ${data.error} - ${data.error_description}`,
+    );
+  }
+
+  if (!data.refresh_token) {
+    throw new Error("リフレッシュトークンが取得できませんでした");
+  }
+
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000);
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt,
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,16 +18,18 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  entries              Entry[]
-  reports              Report[]
-  ownedProjects        Project[]             @relation("ProjectOwner")
-  projectMembers       ProjectMember[]
-  assignedTasks        Task[]                @relation("TaskAssignee")
-  reportTemplates      ReportTemplate[]
-  reactions            Reaction[]
-  comments             Comment[]
-  standups             Standup[]
-  integrationSettings  IntegrationSetting[]
+  entries                  Entry[]
+  reports                  Report[]
+  ownedProjects            Project[]                 @relation("ProjectOwner")
+  projectMembers           ProjectMember[]
+  assignedTasks            Task[]                    @relation("TaskAssignee")
+  reportTemplates          ReportTemplate[]
+  reactions                Reaction[]
+  comments                 Comment[]
+  standups                 Standup[]
+  integrationSettings      IntegrationSetting[]
+  githubConnection         GitHubConnection?
+  googleCalendarConnection GoogleCalendarConnection?
 
   @@map("users")
 }
@@ -261,4 +263,36 @@ model IntegrationSetting {
 enum IntegrationType {
   SLACK
   DISCORD
+  GITHUB
+  GOOGLE_CALENDAR
+}
+
+model GitHubConnection {
+  id              String    @id @default(cuid())
+  userId          String    @unique
+  accessToken     String
+  githubUserId    String
+  githubLogin     String
+  lastImportedAt  DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("github_connections")
+}
+
+model GoogleCalendarConnection {
+  id           String   @id @default(cuid())
+  userId       String   @unique
+  accessToken  String
+  refreshToken String
+  expiresAt    DateTime
+  calendarIds  String[]
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("google_calendar_connections")
 }

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,4 +1,5 @@
 import { type PageProps } from "$fresh/server.ts";
+import PwaInstallPrompt from "../islands/PwaInstallPrompt.tsx";
 
 export default function App({ Component }: PageProps) {
   return (
@@ -6,15 +7,23 @@ export default function App({ Component }: PageProps) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="theme-color" content="#6366f1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content="murlon" />
         <title>murlon - 書くだけで日報が完成する</title>
+        <link rel="manifest" href="/manifest.json" />
         <link rel="stylesheet" href="/styles.css" />
+        <link rel="stylesheet" href="/print.css" />
         <link
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
           rel="stylesheet"
         />
+        <script src="/sw-register.js" defer />
       </head>
       <body class="bg-gray-50 font-sans text-gray-900 min-h-screen">
         <Component />
+        <PwaInstallPrompt />
       </body>
     </html>
   );

--- a/routes/api/calendar/auth.ts
+++ b/routes/api/calendar/auth.ts
@@ -1,0 +1,52 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/auth/login" },
+      });
+    }
+
+    const clientId = Deno.env.get("GOOGLE_CLIENT_ID");
+    const redirectUri = Deno.env.get("GOOGLE_REDIRECT_URI");
+
+    if (!clientId || !redirectUri) {
+      return new Response("Google Calendar連携が設定されていません", {
+        status: 500,
+      });
+    }
+
+    // stateパラメータとしてランダムトークンを生成し、KVにユーザーIDを紐付けて保存
+    const stateBytes = new Uint8Array(16);
+    crypto.getRandomValues(stateBytes);
+    const state = Array.from(stateBytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    const kv = await Deno.openKv();
+    await kv.set(["google_oauth_state", state], session.userId, {
+      expireIn: 10 * 60 * 1000, // 10分間有効
+    });
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope: "https://www.googleapis.com/auth/calendar.readonly",
+      access_type: "offline",
+      prompt: "consent",
+      state,
+    });
+
+    const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+
+    return new Response(null, {
+      status: 302,
+      headers: { Location: authUrl },
+    });
+  },
+};

--- a/routes/api/calendar/callback.ts
+++ b/routes/api/calendar/callback.ts
@@ -1,0 +1,110 @@
+import { type Handlers } from "$fresh/server.ts";
+import { prisma } from "../../../lib/db.ts";
+import { exchangeCodeForTokens } from "../../../lib/google-calendar.ts";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const url = new URL(req.url);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
+
+    if (error) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `/settings/google-calendar?error=${
+            encodeURIComponent(
+              "Google認証がキャンセルされました",
+            )
+          }`,
+        },
+      });
+    }
+
+    if (!code || !state) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `/settings/google-calendar?error=${
+            encodeURIComponent(
+              "不正なリクエストです",
+            )
+          }`,
+        },
+      });
+    }
+
+    // stateを検証してユーザーIDを取得
+    const kv = await Deno.openKv();
+    const stateResult = await kv.get<string>(["google_oauth_state", state]);
+    const userId = stateResult.value;
+
+    if (!userId) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `/settings/google-calendar?error=${
+            encodeURIComponent(
+              "認証セッションが期限切れです。もう一度お試しください",
+            )
+          }`,
+        },
+      });
+    }
+
+    // 使用済みのstateを削除
+    await kv.delete(["google_oauth_state", state]);
+
+    const redirectUri = Deno.env.get("GOOGLE_REDIRECT_URI");
+    if (!redirectUri) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `/settings/google-calendar?error=${
+            encodeURIComponent(
+              "サーバー設定エラーです",
+            )
+          }`,
+        },
+      });
+    }
+
+    try {
+      const tokens = await exchangeCodeForTokens(code, redirectUri);
+
+      // GoogleCalendarConnectionをupsert（既存の場合は更新）
+      await prisma.googleCalendarConnection.upsert({
+        where: { userId },
+        update: {
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+        },
+        create: {
+          userId,
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+        },
+      });
+
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/settings/google-calendar" },
+      });
+    } catch (err) {
+      console.error("Google Calendar OAuth callback error:", err);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `/settings/google-calendar?error=${
+            encodeURIComponent(
+              "トークンの取得に失敗しました",
+            )
+          }`,
+        },
+      });
+    }
+  },
+};

--- a/routes/api/calendar/disconnect.ts
+++ b/routes/api/calendar/disconnect.ts
@@ -1,0 +1,38 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+import { prisma } from "../../../lib/db.ts";
+import type { ApiResponse } from "../../../lib/types.ts";
+
+export const handler: Handlers = {
+  async DELETE(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return Response.json(
+        { success: false, error: "認証が必要です" } satisfies ApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const connection = await prisma.googleCalendarConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    if (!connection) {
+      return Response.json(
+        {
+          success: false,
+          error: "Google Calendarの連携が見つかりません",
+        } satisfies ApiResponse,
+        { status: 404 },
+      );
+    }
+
+    await prisma.googleCalendarConnection.delete({
+      where: { id: connection.id },
+    });
+
+    return Response.json(
+      { success: true } satisfies ApiResponse,
+    );
+  },
+};

--- a/routes/api/calendar/events.ts
+++ b/routes/api/calendar/events.ts
@@ -1,0 +1,116 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+import { prisma } from "../../../lib/db.ts";
+import {
+  fetchEvents,
+  formatEventForDisplay,
+  refreshAccessToken,
+} from "../../../lib/google-calendar.ts";
+import type { ApiResponse } from "../../../lib/types.ts";
+
+interface CalendarEventResponse {
+  id: string;
+  summary: string;
+  startTime: string | null;
+  endTime: string | null;
+  isAllDay: boolean;
+  description: string | null;
+  location: string | null;
+  displayText: string;
+}
+
+export const handler: Handlers = {
+  async GET(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return Response.json(
+        { success: false, error: "認証が必要です" } satisfies ApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const url = new URL(req.url);
+    const date = url.searchParams.get("date") ||
+      new Date().toISOString().slice(0, 10);
+
+    // YYYY-MM-DD形式の簡易バリデーション
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return Response.json(
+        {
+          success: false,
+          error: "日付はYYYY-MM-DD形式で指定してください",
+        } satisfies ApiResponse,
+        { status: 400 },
+      );
+    }
+
+    const connection = await prisma.googleCalendarConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    if (!connection) {
+      return Response.json(
+        {
+          success: false,
+          error: "Google Calendarが連携されていません",
+        } satisfies ApiResponse,
+        { status: 404 },
+      );
+    }
+
+    let accessToken = connection.accessToken;
+
+    // トークンが期限切れの場合はリフレッシュ
+    if (new Date() >= connection.expiresAt) {
+      try {
+        const refreshed = await refreshAccessToken(connection.refreshToken);
+        accessToken = refreshed.accessToken;
+
+        await prisma.googleCalendarConnection.update({
+          where: { id: connection.id },
+          data: {
+            accessToken: refreshed.accessToken,
+            expiresAt: refreshed.expiresAt,
+          },
+        });
+      } catch (err) {
+        console.error("トークン更新エラー:", err);
+        return Response.json(
+          {
+            success: false,
+            error: "トークンの更新に失敗しました。再連携してください",
+          } satisfies ApiResponse,
+          { status: 401 },
+        );
+      }
+    }
+
+    try {
+      const events = await fetchEvents(accessToken, date);
+
+      const data: CalendarEventResponse[] = events.map((event) => ({
+        id: event.id,
+        summary: event.summary || "(無題)",
+        startTime: event.start.dateTime ?? event.start.date ?? null,
+        endTime: event.end.dateTime ?? event.end.date ?? null,
+        isAllDay: !event.start.dateTime,
+        description: event.description ?? null,
+        location: event.location ?? null,
+        displayText: formatEventForDisplay(event),
+      }));
+
+      return Response.json(
+        { success: true, data } satisfies ApiResponse<CalendarEventResponse[]>,
+      );
+    } catch (err) {
+      console.error("カレンダーイベント取得エラー:", err);
+      return Response.json(
+        {
+          success: false,
+          error: "カレンダーイベントの取得に失敗しました",
+        } satisfies ApiResponse,
+        { status: 500 },
+      );
+    }
+  },
+};

--- a/routes/api/github/auth.ts
+++ b/routes/api/github/auth.ts
@@ -1,0 +1,49 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+
+const KV_GITHUB_STATE_PREFIX = "github_oauth_state:";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/auth/login" },
+      });
+    }
+
+    const clientId = Deno.env.get("GITHUB_CLIENT_ID");
+    if (!clientId) {
+      return new Response("GitHub連携が設定されていません", { status: 500 });
+    }
+
+    // stateパラメータ生成・KV保存
+    const stateBytes = new Uint8Array(16);
+    crypto.getRandomValues(stateBytes);
+    const state = Array.from(stateBytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    const kv = await Deno.openKv();
+    await kv.set(
+      [KV_GITHUB_STATE_PREFIX + state],
+      session.userId,
+      { expireIn: 10 * 60 * 1000 }, // 10分
+    );
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      scope: "repo",
+      state,
+      redirect_uri: new URL("/api/github/callback", req.url).toString(),
+    });
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: `https://github.com/login/oauth/authorize?${params}`,
+      },
+    });
+  },
+};

--- a/routes/api/github/callback.ts
+++ b/routes/api/github/callback.ts
@@ -1,0 +1,67 @@
+import { type Handlers } from "$fresh/server.ts";
+import { prisma } from "../../../lib/db.ts";
+import { exchangeCodeForToken, fetchGitHubUser } from "../../../lib/github.ts";
+
+const KV_GITHUB_STATE_PREFIX = "github_oauth_state:";
+
+export const handler: Handlers = {
+  async GET(req) {
+    const url = new URL(req.url);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+
+    if (!code || !state) {
+      return new Response("無効なリクエストです", { status: 400 });
+    }
+
+    // state検証
+    const kv = await Deno.openKv();
+    const stateResult = await kv.get<string>([KV_GITHUB_STATE_PREFIX + state]);
+    const userId = stateResult.value;
+
+    if (!userId) {
+      return new Response("認証セッションが無効または期限切れです", { status: 400 });
+    }
+
+    // state消費（再利用防止）
+    await kv.delete([KV_GITHUB_STATE_PREFIX + state]);
+
+    const clientId = Deno.env.get("GITHUB_CLIENT_ID");
+    const clientSecret = Deno.env.get("GITHUB_CLIENT_SECRET");
+    if (!clientId || !clientSecret) {
+      return new Response("GitHub連携が設定されていません", { status: 500 });
+    }
+
+    try {
+      // codeをアクセストークンに交換
+      const accessToken = await exchangeCodeForToken(code, clientId, clientSecret);
+
+      // GitHubユーザー情報取得
+      const ghUser = await fetchGitHubUser(accessToken);
+
+      // GitHubConnectionをDB保存（upsert）
+      await prisma.gitHubConnection.upsert({
+        where: { userId },
+        create: {
+          userId,
+          accessToken,
+          githubUserId: String(ghUser.id),
+          githubLogin: ghUser.login,
+        },
+        update: {
+          accessToken,
+          githubUserId: String(ghUser.id),
+          githubLogin: ghUser.login,
+        },
+      });
+
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/settings/github" },
+      });
+    } catch (err) {
+      console.error("GitHub OAuth callback error:", err);
+      return new Response("GitHub認証に失敗しました", { status: 500 });
+    }
+  },
+};

--- a/routes/api/github/disconnect.ts
+++ b/routes/api/github/disconnect.ts
@@ -1,0 +1,35 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+import { prisma } from "../../../lib/db.ts";
+import type { ApiResponse } from "../../../lib/types.ts";
+
+export const handler: Handlers = {
+  async DELETE(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return Response.json(
+        { success: false, error: "認証が必要です" } satisfies ApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const connection = await prisma.gitHubConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    if (!connection) {
+      return Response.json(
+        { success: false, error: "GitHub連携が設定されていません" } satisfies ApiResponse,
+        { status: 404 },
+      );
+    }
+
+    await prisma.gitHubConnection.delete({
+      where: { userId: session.userId },
+    });
+
+    return Response.json(
+      { success: true } satisfies ApiResponse,
+    );
+  },
+};

--- a/routes/api/github/import.ts
+++ b/routes/api/github/import.ts
@@ -1,0 +1,101 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+import { prisma } from "../../../lib/db.ts";
+import { fetchCommits, formatCommitAsEntry } from "../../../lib/github.ts";
+import type { ApiResponse } from "../../../lib/types.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return Response.json(
+        { success: false, error: "認証が必要です" } satisfies ApiResponse,
+        { status: 401 },
+      );
+    }
+
+    let body: {
+      owner?: string;
+      repo?: string;
+      since?: string;
+      until?: string;
+    };
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json(
+        { success: false, error: "無効なリクエストです" } satisfies ApiResponse,
+        { status: 400 },
+      );
+    }
+
+    if (!body.owner || !body.repo) {
+      return Response.json(
+        {
+          success: false,
+          error: "ownerとrepoは必須です",
+        } satisfies ApiResponse,
+        { status: 400 },
+      );
+    }
+
+    const connection = await prisma.gitHubConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    if (!connection) {
+      return Response.json(
+        { success: false, error: "GitHub連携が設定されていません" } satisfies ApiResponse,
+        { status: 404 },
+      );
+    }
+
+    try {
+      const commits = await fetchCommits(
+        connection.accessToken,
+        body.owner,
+        body.repo,
+        body.since,
+        body.until,
+      );
+
+      // 各コミットをEntryとして保存
+      let importedCount = 0;
+      for (const commit of commits) {
+        const content = formatCommitAsEntry(
+          commit,
+          `${body.owner}/${body.repo}`,
+        );
+        await prisma.entry.create({
+          data: {
+            content,
+            userId: session.userId,
+          },
+        });
+        importedCount++;
+      }
+
+      // lastImportedAtを更新
+      await prisma.gitHubConnection.update({
+        where: { userId: session.userId },
+        data: { lastImportedAt: new Date() },
+      });
+
+      return Response.json(
+        {
+          success: true,
+          data: { importedCount },
+        } satisfies ApiResponse<{ importedCount: number }>,
+      );
+    } catch (err) {
+      console.error("GitHub import error:", err);
+      return Response.json(
+        {
+          success: false,
+          error: "コミットのインポートに失敗しました",
+        } satisfies ApiResponse,
+        { status: 500 },
+      );
+    }
+  },
+};

--- a/routes/api/github/repos.ts
+++ b/routes/api/github/repos.ts
@@ -1,0 +1,62 @@
+import { type Handlers } from "$fresh/server.ts";
+import { getSession } from "../../../lib/auth.ts";
+import { prisma } from "../../../lib/db.ts";
+import { fetchRepos } from "../../../lib/github.ts";
+import type { ApiResponse } from "../../../lib/types.ts";
+
+interface RepoData {
+  name: string;
+  fullName: string;
+  owner: string;
+  description: string | null;
+  private: boolean;
+  updatedAt: string;
+}
+
+export const handler: Handlers = {
+  async GET(req) {
+    const session = await getSession(req);
+    if (!session) {
+      return Response.json(
+        { success: false, error: "認証が必要です" } satisfies ApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const connection = await prisma.gitHubConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    if (!connection) {
+      return Response.json(
+        { success: false, error: "GitHub連携が設定されていません" } satisfies ApiResponse,
+        { status: 404 },
+      );
+    }
+
+    try {
+      const repos = await fetchRepos(connection.accessToken);
+      const data: RepoData[] = repos.map((r) => ({
+        name: r.name,
+        fullName: r.full_name,
+        owner: r.owner.login,
+        description: r.description,
+        private: r.private,
+        updatedAt: r.updated_at,
+      }));
+
+      return Response.json(
+        { success: true, data } satisfies ApiResponse<RepoData[]>,
+      );
+    } catch (err) {
+      console.error("GitHub repos fetch error:", err);
+      return Response.json(
+        {
+          success: false,
+          error: "リポジトリの取得に失敗しました",
+        } satisfies ApiResponse,
+        { status: 500 },
+      );
+    }
+  },
+};

--- a/routes/dashboard.tsx
+++ b/routes/dashboard.tsx
@@ -3,6 +3,7 @@ import { getSession } from "../lib/auth.ts";
 import { prisma } from "../lib/db.ts";
 import Header from "../components/Header.tsx";
 import DashboardIsland from "../islands/DashboardIsland.tsx";
+import CalendarEvents from "../islands/CalendarEvents.tsx";
 import type { EntryRecord, ReportRecord, ReportType } from "../lib/types.ts";
 
 interface DashboardData {
@@ -99,6 +100,8 @@ export default function Dashboard({ data }: PageProps<DashboardData>) {
           </h1>
           <p class="text-gray-500 mt-1">今日も一言から始めましょう</p>
         </div>
+
+        <CalendarEvents />
 
         <DashboardIsland
           initialEntries={entries}

--- a/routes/projects/[id]/reports.tsx
+++ b/routes/projects/[id]/reports.tsx
@@ -3,6 +3,7 @@ import { getSession } from "../../../lib/auth.ts";
 import { prisma } from "../../../lib/db.ts";
 import Header from "../../../components/Header.tsx";
 import ReportView from "../../../islands/ReportView.tsx";
+import PdfExportButton from "../../../islands/PdfExportButton.tsx";
 import type {
   EntryRecord,
   ReportRecord,
@@ -214,6 +215,9 @@ export default function ProjectReportsPage({ data }: PageProps<ProjectReportsPag
           <h1 class="text-2xl font-bold text-gray-900">
             {project.name} - レポート
           </h1>
+          <PdfExportButton
+            title={`${project.name}_${reportTypeLabel(reportType)}_${startDate}`}
+          />
         </div>
 
         {/* Report type tabs */}

--- a/routes/reports/daily.tsx
+++ b/routes/reports/daily.tsx
@@ -3,6 +3,7 @@ import { getSession } from "../../lib/auth.ts";
 import { prisma } from "../../lib/db.ts";
 import Header from "../../components/Header.tsx";
 import ReportView from "../../islands/ReportView.tsx";
+import PdfExportButton from "../../islands/PdfExportButton.tsx";
 import type { EntryRecord, ReportRecord } from "../../lib/types.ts";
 
 interface ReportPageData {
@@ -92,6 +93,7 @@ export default function DailyReportPage({ data }: PageProps<ReportPageData>) {
             </p>
           </div>
           <div class="flex gap-2">
+            <PdfExportButton title={`日報_${date}`} />
             <a
               href={`/reports/daily?date=${getPrevDate(date)}`}
               class="px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-100"

--- a/routes/reports/monthly.tsx
+++ b/routes/reports/monthly.tsx
@@ -3,6 +3,7 @@ import { getSession } from "../../lib/auth.ts";
 import { prisma } from "../../lib/db.ts";
 import Header from "../../components/Header.tsx";
 import ReportView from "../../islands/ReportView.tsx";
+import PdfExportButton from "../../islands/PdfExportButton.tsx";
 import type { EntryRecord, ReportRecord } from "../../lib/types.ts";
 
 interface MonthlyReportData {
@@ -91,6 +92,7 @@ export default function MonthlyReportPage({ data }: PageProps<MonthlyReportData>
             </p>
           </div>
           <div class="flex gap-2">
+            <PdfExportButton title={`月報_${year}年${month}月`} />
             <a
               href={`/reports/monthly?year=${prevMonth.year}&month=${prevMonth.month}`}
               class="px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-100"

--- a/routes/reports/weekly.tsx
+++ b/routes/reports/weekly.tsx
@@ -3,6 +3,7 @@ import { getSession } from "../../lib/auth.ts";
 import { prisma } from "../../lib/db.ts";
 import Header from "../../components/Header.tsx";
 import ReportView from "../../islands/ReportView.tsx";
+import PdfExportButton from "../../islands/PdfExportButton.tsx";
 import type { EntryRecord, ReportRecord } from "../../lib/types.ts";
 
 interface WeeklyReportData {
@@ -110,6 +111,7 @@ export default function WeeklyReportPage({ data }: PageProps<WeeklyReportData>) 
             </p>
           </div>
           <div class="flex gap-2">
+            <PdfExportButton title={`週報_${weekStart}_${weekEnd}`} />
             <a
               href={`/reports/weekly?date=${prevWeek}`}
               class="px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-100"

--- a/routes/settings/github.tsx
+++ b/routes/settings/github.tsx
@@ -1,0 +1,70 @@
+import { type Handlers, type PageProps } from "$fresh/server.ts";
+import { getSession } from "../../lib/auth.ts";
+import { prisma } from "../../lib/db.ts";
+import Header from "../../components/Header.tsx";
+import GitHubSettingsIsland from "../../islands/GitHubSettingsIsland.tsx";
+
+interface GitHubPageData {
+  user: { id: string; name: string; email: string };
+  connection: {
+    githubLogin: string;
+    lastImportedAt: string | null;
+  } | null;
+}
+
+export const handler: Handlers<GitHubPageData> = {
+  async GET(req, ctx) {
+    const session = await getSession(req);
+    if (!session) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/auth/login" },
+      });
+    }
+
+    const conn = await prisma.gitHubConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    return ctx.render({
+      user: { id: session.userId, name: session.name, email: session.email },
+      connection: conn
+        ? {
+          githubLogin: conn.githubLogin,
+          lastImportedAt: conn.lastImportedAt?.toISOString() ?? null,
+        }
+        : null,
+    });
+  },
+};
+
+export default function GitHubSettingsPage(
+  { data }: PageProps<GitHubPageData>,
+) {
+  const { user, connection } = data;
+
+  return (
+    <div class="min-h-screen bg-gray-50">
+      <Header user={user} />
+      <main class="max-w-2xl mx-auto px-4 py-8">
+        {/* Breadcrumb */}
+        <div class="text-sm text-gray-500 mb-4">
+          <a href="/dashboard" class="hover:text-brand-600">設定</a>
+          <span class="mx-1">/</span>
+          <span class="text-gray-700">GitHub連携</span>
+        </div>
+
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-gray-900">GitHub連携</h1>
+          <p class="text-gray-500 mt-1">
+            GitHubリポジトリのコミットを分報としてインポートできます
+          </p>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <GitHubSettingsIsland connection={connection} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/routes/settings/google-calendar.tsx
+++ b/routes/settings/google-calendar.tsx
@@ -1,0 +1,103 @@
+import { type Handlers, type PageProps } from "$fresh/server.ts";
+import { getSession } from "../../lib/auth.ts";
+import { prisma } from "../../lib/db.ts";
+import Header from "../../components/Header.tsx";
+import GoogleCalendarDisconnect from "../../islands/GoogleCalendarDisconnect.tsx";
+
+interface GoogleCalendarPageData {
+  user: { id: string; name: string; email: string };
+  isConnected: boolean;
+  error?: string;
+}
+
+export const handler: Handlers<GoogleCalendarPageData> = {
+  async GET(req, ctx) {
+    const session = await getSession(req);
+    if (!session) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/auth/login" },
+      });
+    }
+
+    const connection = await prisma.googleCalendarConnection.findUnique({
+      where: { userId: session.userId },
+    });
+
+    const url = new URL(req.url);
+    const error = url.searchParams.get("error") ?? undefined;
+
+    return ctx.render({
+      user: { id: session.userId, name: session.name, email: session.email },
+      isConnected: !!connection,
+      error,
+    });
+  },
+};
+
+export default function GoogleCalendarPage(
+  { data }: PageProps<GoogleCalendarPageData>,
+) {
+  const { user, isConnected, error } = data;
+
+  return (
+    <div class="min-h-screen bg-gray-50">
+      <Header user={user} />
+      <main class="max-w-2xl mx-auto px-4 py-8">
+        {/* Breadcrumb */}
+        <div class="text-sm text-gray-500 mb-4">
+          <a href="/dashboard" class="hover:text-brand-600">設定</a>
+          <span class="mx-1">/</span>
+          <span class="text-gray-700">Google Calendar連携</span>
+        </div>
+
+        <div class="mb-6">
+          <h1 class="text-2xl font-bold text-gray-900">
+            Google Calendar連携
+          </h1>
+          <p class="text-gray-500 mt-1">
+            Google Calendarと連携して、今日の予定を分報画面に表示できます
+          </p>
+        </div>
+
+        {error && (
+          <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4">
+            {error}
+          </div>
+        )}
+
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          {isConnected
+            ? (
+              <div>
+                <div class="flex items-center gap-3 mb-4">
+                  <div class="w-3 h-3 bg-green-500 rounded-full" />
+                  <span class="text-gray-800 font-medium">
+                    Google Calendarと連携済み
+                  </span>
+                </div>
+                <p class="text-gray-500 text-sm mb-4">
+                  ダッシュボードに今日のカレンダーイベントが表示されます。
+                </p>
+                <GoogleCalendarDisconnect />
+              </div>
+            )
+            : (
+              <div>
+                <p class="text-gray-600 mb-4">
+                  Google
+                  Calendarと連携すると、今日の予定をダッシュボードで確認できるようになります。
+                </p>
+                <a
+                  href="/api/calendar/auth"
+                  class="inline-block bg-brand-600 hover:bg-brand-700 text-white font-semibold px-6 py-2.5 rounded-lg transition-colors"
+                >
+                  Google Calendarと連携する
+                </a>
+              </div>
+            )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/routes/settings/index.tsx
+++ b/routes/settings/index.tsx
@@ -58,6 +58,36 @@ export default function SettingsPage({ data }: PageProps<SettingsPageData>) {
               <span class="text-gray-400">→</span>
             </div>
           </a>
+
+          <a
+            href="/settings/github"
+            class="block bg-white rounded-xl shadow-sm border border-gray-200 p-5 hover:border-brand-300 hover:shadow-md transition-all"
+          >
+            <div class="flex items-center justify-between">
+              <div>
+                <h2 class="text-base font-semibold text-gray-900">GitHub連携</h2>
+                <p class="text-sm text-gray-500 mt-0.5">
+                  GitHubのコミット履歴を分報として自動インポートします
+                </p>
+              </div>
+              <span class="text-gray-400">→</span>
+            </div>
+          </a>
+
+          <a
+            href="/settings/google-calendar"
+            class="block bg-white rounded-xl shadow-sm border border-gray-200 p-5 hover:border-brand-300 hover:shadow-md transition-all"
+          >
+            <div class="flex items-center justify-between">
+              <div>
+                <h2 class="text-base font-semibold text-gray-900">Google Calendar連携</h2>
+                <p class="text-sm text-gray-500 mt-0.5">
+                  Google Calendarのスケジュールを分報作成時に参照できます
+                </p>
+              </div>
+              <span class="text-gray-400">→</span>
+            </div>
+          </a>
         </div>
       </main>
     </div>

--- a/static/icons/icon.svg
+++ b/static/icons/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#6366f1" />
+  <text
+    x="256"
+    y="360"
+    font-family="Arial, sans-serif"
+    font-size="320"
+    font-weight="bold"
+    fill="#ffffff"
+    text-anchor="middle"
+  >M</text>
+</svg>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "murlon",
+  "short_name": "murlon",
+  "description": "書くだけで日報が完成する",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#6366f1",
+  "lang": "ja",
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "分報を書く",
+      "url": "/dashboard",
+      "description": "ダッシュボードを開く"
+    }
+  ]
+}

--- a/static/offline.html
+++ b/static/offline.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>オフライン - murlon</title>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family: "Noto Sans JP", sans-serif;
+        background-color: #f9fafb;
+        color: #111827;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .container {
+        text-align: center;
+        padding: 2rem;
+      }
+      .icon {
+        width: 80px;
+        height: 80px;
+        margin: 0 auto 1.5rem;
+        background-color: #eef2ff;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .icon svg {
+        width: 40px;
+        height: 40px;
+        color: #6366f1;
+      }
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #6366f1;
+        margin-bottom: 0.75rem;
+      }
+      p {
+        font-size: 1rem;
+        color: #6b7280;
+        margin-bottom: 1.5rem;
+      }
+      button {
+        background-color: #6366f1;
+        color: #ffffff;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      button:hover {
+        background-color: #4f46e5;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="icon">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+      </div>
+      <h1>murlon</h1>
+      <p>オフラインです。ネットワーク接続を確認してください。</p>
+      <button onclick="location.reload()">再読み込み</button>
+    </div>
+  </body>
+</html>

--- a/static/print.css
+++ b/static/print.css
@@ -1,0 +1,54 @@
+@media print {
+  /* ナビゲーション・ヘッダー・ボタン類を非表示 */
+  nav, header, .no-print, button, .print-hidden {
+    display: none !important;
+  }
+
+  /* ページ設定 */
+  @page {
+    margin: 2cm;
+    size: A4 portrait;
+  }
+
+  /* フォント設定 */
+  body {
+    font-family: "Hiragino Sans", "Yu Gothic", sans-serif;
+    font-size: 11pt;
+    color: #000;
+    background: #fff;
+  }
+
+  /* レポートコンテンツの最適化 */
+  .prose, .report-content {
+    max-width: 100% !important;
+  }
+
+  /* ページ区切り */
+  h1, h2 {
+    page-break-after: avoid;
+  }
+  pre, blockquote {
+    page-break-inside: avoid;
+  }
+
+  /* リンクのURL非表示 */
+  a::after {
+    content: "";
+  }
+
+  /* 背景色・影の除去 */
+  * {
+    box-shadow: none !important;
+  }
+
+  /* 印刷タイトルエリア */
+  .print-title {
+    display: block !important;
+    margin-bottom: 1cm;
+  }
+}
+
+/* 画面表示時は非表示 */
+.print-title {
+  display: none;
+}

--- a/static/sw-register.js
+++ b/static/sw-register.js
@@ -1,0 +1,3 @@
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/sw.js");
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = "murlon-v1";
+const STATIC_ASSETS = [
+  "/styles.css",
+  "/icons/icon.svg",
+  "/offline.html",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
+      )
+    ),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  // APIリクエストはキャッシュしない
+  if (url.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  // 静的アセットはCache First
+  if (
+    url.pathname.startsWith("/icons/") ||
+    url.pathname.endsWith(".css") ||
+    url.pathname.endsWith(".js") ||
+    url.pathname.endsWith(".svg")
+  ) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        return cached || fetch(event.request).then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        });
+      }),
+    );
+    return;
+  }
+
+  // その他はNetwork First
+  event.respondWith(
+    fetch(event.request).catch(() => {
+      return caches.match(event.request).then((cached) => {
+        return cached || caches.match("/offline.html");
+      });
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

- **GitHub連携**: GitHubのOAuth認証でコミット履歴を分報として自動インポート
- **Google Calendar連携**: Google CalendarのOAuth認証でスケジュールをダッシュボードに表示
- **PWA対応**: manifest.json・Service Worker・インストールプロンプト・オフラインページ
- **PDFエクスポート**: 印刷用CSS + エクスポートボタンで全レポートをPDF出力可能

## 変更ファイル

### 新規ファイル（28ファイル）
- `lib/github.ts` - GitHub API クライアント
- `lib/google-calendar.ts` - Google Calendar API クライアント（トークン自動リフレッシュ対応）
- `routes/api/github/` - OAuth認証・コミットインポート・リポジトリ一覧・連携解除
- `routes/api/calendar/` - OAuth認証・イベント取得・連携解除
- `routes/settings/github.tsx` - GitHub連携設定ページ
- `routes/settings/google-calendar.tsx` - Google Calendar連携設定ページ
- `islands/GitHubSettingsIsland.tsx` - リポジトリ選択・インポートUI
- `islands/CalendarEvents.tsx` - 今日のカレンダーイベント表示
- `islands/GoogleCalendarDisconnect.tsx` - Calendar連携解除ボタン
- `islands/PwaInstallPrompt.tsx` - ホーム画面追加プロンプト
- `islands/PdfExportButton.tsx` - PDF出力ボタン
- `static/manifest.json`, `static/sw.js`, `static/sw-register.js` - PWA
- `static/offline.html`, `static/icons/icon.svg` - PWA
- `static/print.css` - 印刷用スタイルシート

### 変更ファイル（6ファイル）
- `prisma/schema.prisma` - `GitHubConnection`・`GoogleCalendarConnection` モデル追加
- `deno.json` - `compilerOptions.lib` に `deno.unstable` を追加
- `routes/_app.tsx` - PWAメタタグ・manifest・print.css・Service Worker登録追加
- `routes/dashboard.tsx` - `CalendarEvents` Island を組み込み
- `routes/settings/index.tsx` - GitHub・Google Calendar連携へのリンク追加
- `routes/reports/daily.tsx`, `weekly.tsx`, `monthly.tsx`, `routes/projects/[id]/reports.tsx` - PDFエクスポートボタン追加

## セットアップ手順

### DBマイグレーション
```bash
deno task docker:up
deno task db:push
```

### 環境変数（.env）
```
# GitHub OAuth
GITHUB_CLIENT_ID=...
GITHUB_CLIENT_SECRET=...

# Google OAuth
GOOGLE_CLIENT_ID=...
GOOGLE_CLIENT_SECRET=...
GOOGLE_REDIRECT_URI=http://localhost:8000/api/calendar/callback
```

### OAuth登録
- **GitHub**: https://github.com/settings/developers でOAuthアプリ作成、コールバックURL: `/api/github/callback`
- **Google**: Cloud Consoleでカレンダー用OAuthクライアントID作成、Calendar API v3を有効化

## Test plan
- [ ] Docker起動後 `deno task db:push` でDBスキーマが正常に反映される
- [ ] `/settings` ページにGitHub・Google Calendarへのリンクが表示される
- [ ] GitHub OAuth連携フロー（認証 → コールバック → コミットインポート）が動作する
- [ ] Google Calendar OAuth連携フロー（認証 → コールバック → イベント表示）が動作する
- [ ] ダッシュボードに今日のカレンダーイベントが表示される（Calendar連携時）
- [ ] 各レポートページでPDFエクスポートボタンが表示され、印刷ダイアログが開く
- [ ] モバイルブラウザでPWAインストールプロンプトが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)